### PR TITLE
Added Score!

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <!-- Odibee Sans: https://fonts.google.com/specimen/Odibee+Sans -->
     <!-- Inter: https://fonts.google.com/specimen/Inter -->
     <!-- Material Symbols: https://fonts.google.com/icons -->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Odibee+Sans&family=Roboto+Condensed:wght@400;700&family=Material+Symbols+Rounded&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Odibee+Sans&family=Roboto+Condensed:wght@400;700&family=Material+Symbols+Rounded:FILL@0..1&display=swap" />
 
     <script defer src="/src/index.tsx" type="module"></script>
   </head>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .symbol-fill {
+    font-variation-settings: "FILL" 1;
+  }
+}
+
 html,
 body {
   height: 100%;

--- a/src/react/components/Header.tsx
+++ b/src/react/components/Header.tsx
@@ -2,14 +2,17 @@ import { useDispatch, useSelector } from "@tower-of-hanoi/redux/hooks";
 import {
   gameInitialize,
   selectGameDiskCount,
-  selectGameMoveCount
+  selectGameMinMoveCount,
+  selectGameMoveCount,
+  selectGameScore
 } from "@tower-of-hanoi/redux/slices/game";
 
 export default function Header() {
   const dispatch = useDispatch();
-
-  const moveCount = useSelector(selectGameMoveCount);
   const diskCount = useSelector(selectGameDiskCount);
+  const minMoveCount = useSelector(selectGameMinMoveCount);
+  const moveCount = useSelector(selectGameMoveCount);
+  const score = useSelector(selectGameScore);
 
   return (
     <header className="grid select-none grid-cols-[1fr_auto] py-6 text-charcoal-500 max-sm:py-4">
@@ -43,16 +46,27 @@ export default function Header() {
 
         {/* Stats */}
         <div>
-          <h5 className="text-2xl font-bold leading-tight">{"00:00:00"}</h5>
-          <h4 className="whitespace-nowrap leading-none">
+          <h4 className="whitespace-nowrap pl-0.5 leading-none">
+            <span className="text-xl font-bold">{diskCount}</span>
+            <span className="text-charcoal-400"> disks</span>
+          </h4>
+          <h4 className="whitespace-nowrap pl-0.5 leading-none">
             <span className="text-xl font-bold">
-              {moveCount} / {Math.pow(2, diskCount) - 1}
+              {moveCount} / {minMoveCount}
             </span>
             <span className="text-charcoal-400"> moves</span>
           </h4>
           <h4 className="whitespace-nowrap leading-none">
-            <span className="text-xl font-bold">{"0"}</span>
-            <span className="text-charcoal-400"> score</span>
+            {Array.from(Array(score), (_, key) => (
+              <span className="material-symbols-rounded symbol-fill" key={key}>
+                star
+              </span>
+            ))}
+            {Array.from(Array(3 - score), (_, key) => (
+              <span className="material-symbols-rounded" key={key}>
+                star
+              </span>
+            ))}
           </h4>
         </div>
       </div>

--- a/src/redux/slices/game.test.ts
+++ b/src/redux/slices/game.test.ts
@@ -13,8 +13,9 @@ describe("'game/initialize' action type", () => {
     expect(nextState).toStrictEqual(
       expect.objectContaining<GameState>({
         diskCount,
+        minMoveCount: 255,
         moveCount: 0,
-        scoreMultiplier: 0,
+        score: 0,
         selectableTowers: [0],
         selectedTowerIndex: null,
         towers: [[1, 2, 3, 4, 5, 6, 7, 8], [], []]
@@ -30,8 +31,9 @@ describe("'game/initialize' action type", () => {
     expect(nextState).toStrictEqual(
       expect.objectContaining<GameState>({
         diskCount,
+        minMoveCount: 31,
         moveCount: 0,
-        scoreMultiplier: 0,
+        score: 0,
         selectableTowers: [0],
         selectedTowerIndex: null,
         towers: [[1, 2, 3, 4, 5], [], []]

--- a/src/redux/slices/game.ts
+++ b/src/redux/slices/game.ts
@@ -5,10 +5,12 @@ import type { RootState } from "@tower-of-hanoi/redux/store";
 export interface GameState {
   /** The current total number of disks in play */
   diskCount: number;
+  /** The minimum number of moves needed to complete a puzzle */
+  minMoveCount: number;
   /** The number of moves made by the player */
   moveCount: number;
-  /** A number between 0 and 1 representing the score multiplier  */
-  scoreMultiplier: number;
+  /** A number between 0 and 3 representing the score for the current puzzle */
+  score: number;
   /** A list of indices of selectable towers; determined by `selectedTowerIndex` */
   selectableTowers: number[];
   /** The index of the currently selected tower */
@@ -17,16 +19,37 @@ export interface GameState {
   towers: [start: number[], offset: number[], end: number[]];
 }
 
-const TOWER_INDICES = [0, 1, 2];
-
 export const createInitialState = (diskCount = 4): GameState => ({
   diskCount,
+  minMoveCount: 2 ** diskCount - 1,
   moveCount: 0,
-  scoreMultiplier: 0,
+  score: 0,
   selectableTowers: [0],
   selectedTowerIndex: null,
   towers: [Array.from(Array(diskCount), (_, k) => k + 1), [], []]
 });
+
+const getScore = ({ minMoveCount, moveCount }: GameState) =>
+  moveCount >= minMoveCount
+    ? Math.round(3 * Math.E ** ((moveCount - minMoveCount) / -5))
+    : 0;
+
+const getSelectableTowers = ({ selectedTowerIndex, towers }: GameState) =>
+  towers.reduce((result, tower, index) => {
+    if (selectedTowerIndex === null)
+      return tower.length ? [...result, index] : result;
+
+    if (selectedTowerIndex === index) return [...result, index];
+
+    // The prior clause ensures that only towers with disks are selectable
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const diskA = towers[selectedTowerIndex].at(0)!;
+    const diskB = tower.at(0);
+
+    return typeof diskB === "undefined" || diskA < diskB
+      ? [...result, index]
+      : result;
+  }, []);
 
 const gameSlice = createSlice({
   name: "game",
@@ -35,60 +58,47 @@ const gameSlice = createSlice({
     initialize(state, { payload }: PayloadAction<number | undefined>) {
       return createInitialState(payload ?? state.diskCount);
     },
-    towerSelect(state, { payload }: PayloadAction<number>) {
+    towerSelect(state, { payload: towerIndex }: PayloadAction<number>) {
+      // Don't do anything if the provided towerIndex isn't selectable
+      if (!state.selectableTowers.includes(towerIndex)) return state;
+
       const [sourceIndex, destIndex] =
         state.selectedTowerIndex === null
-          ? [payload]
-          : [state.selectedTowerIndex, payload];
+          ? [towerIndex]
+          : [state.selectedTowerIndex, towerIndex];
 
       // On first selection (e.g. when user is selecting the `sourceIndex`)
       if (typeof destIndex === "undefined") {
-        const diskA = state.towers[sourceIndex].at(0);
-        // ensure the requested selection has at least one disk
-        if (typeof diskA === "undefined") return;
-
-        state.selectableTowers = TOWER_INDICES.filter((towerIndex) => {
-          if (towerIndex === sourceIndex) return true;
-
-          const diskB = state.towers[towerIndex].at(0);
-          return typeof diskB === "undefined" || diskA < diskB;
-        });
         state.selectedTowerIndex = sourceIndex;
-
+        state.selectableTowers = getSelectableTowers(state);
         return;
       }
 
       // On duplicate selection (e.g. when user selects the same tower twice)
       if (sourceIndex === destIndex) {
-        state.selectableTowers = TOWER_INDICES.filter(
-          (towerIndex) => state.towers[towerIndex].length !== 0
-        );
         state.selectedTowerIndex = null;
-
+        state.selectableTowers = getSelectableTowers(state);
         return;
       }
 
       // On valid selection
-      if (state.selectableTowers.includes(destIndex)) {
-        state.moveCount += 1;
-        state.towers[destIndex].unshift(
-          ...state.towers[sourceIndex].splice(0, 1)
-        );
-        state.selectableTowers = TOWER_INDICES.filter(
-          (towerIndex) => state.towers[towerIndex].length !== 0
-        );
-        state.selectedTowerIndex = null;
-
-        return;
-      }
+      state.moveCount += 1;
+      state.score = getScore(state);
+      state.towers[destIndex].unshift(
+        ...state.towers[sourceIndex].splice(0, 1)
+      );
+      state.selectedTowerIndex = null;
+      state.selectableTowers = getSelectableTowers(state);
+      return;
     }
   }
 });
 
 export const selectGameDiskCount = (state: RootState) => state.game.diskCount;
+export const selectGameMinMoveCount = (state: RootState) =>
+  state.game.minMoveCount;
 export const selectGameMoveCount = (state: RootState) => state.game.moveCount;
-export const selectGameScoreMultiplier = (state: RootState) =>
-  state.game.scoreMultiplier;
+export const selectGameScore = (state: RootState) => state.game.score;
 export const selectGameSelectableTowers = (state: RootState) =>
   state.game.selectableTowers;
 export const selectGameSelectedTowerIndex = (state: RootState) =>


### PR DESCRIPTION
(using a 3-star system to "rate" player performance)
- Moved `minMoveCount` to game state slice
- Renamed `scoreMultiplier` to `score` (all calculations should be handled by the reducer)
- The `score` is now determined by an exponential decay equation which takes the `minMoveCount` and `moveCount` as inputs
- Cleaned up the game state slice; added topmost guard clause for tower selection to only allow selectable indices
- Added "FILL" font variation to Material Symbols import and added support via a custom utility class "symbol-fill"